### PR TITLE
Develop dnac 2.2.3.3 - minor struct changes and SetAuthToken fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2022-01-13
+
+### Added
+- application_policy - Adds IndicativeNetworkIdentity property to ResponseItemApplicationPolicyGetApplications struct
+- application_policy - Adds ResponseItemApplicationPolicyGetApplicationsIndicativeNetworkIDentity struct
+
+### Fixed
+- Fix SetAuthToken to use DNAC X-Auth-Token
+- sites - Response of ResponseSitesGetSiteCount type changes from string to *int
+
 ## [3.2.0] - 2022-01-13
 
 ### Added
@@ -17,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixes "Add ability to test via Resty httpmock" [#10](https://github.com/cisco-en-programmability/dnacenter-go-sdk/issues/10)
-- Changes type from int to float64 for GoodPercentage in topology.go
+- Changes type from int to float64 for ResponseTopologyGetOverallNetworkHealthHealthDistirubution.GoodPercentage in topology.go
 
 ## [3.1.1] - 2022-01-10
 
@@ -84,6 +94,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     + RequestConfigurationTemplatesUpdateTemplateValidationErrors
 - Change GetProjectsDetails, GetTemplatesDetails response struct to ResponseConfigurationTemplatesGetProjectsDetails, ResponseConfigurationTemplatesGetTemplatesDetails (which adds response property with a list of previous struct definition)
 
+## [2.2.1] - 2022-01-13
+
+### Fixed
+- Fix SetAuthToken to use DNAC X-Auth-Token
+
 ## [2.2.0] - 2022-01-13
 
 ### Added
@@ -113,6 +128,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update to use DNAC 2.2.2.3
+
+## [1.2.1] - 2022-01-13
+
+### Fixed
+- Fix SetAuthToken to use DNAC X-Auth-Token
 
 ## [1.2.0] - 2022-01-13
 
@@ -190,15 +210,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v0.1.1...v1.0.0
 [1.1.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.0.0...v1.1.0
 [1.2.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.1.0...v1.2.0
+[1.2.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.2.0...v1.2.1
 [2.0.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v1.0.0...v2.0.0
 [2.1.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v2.0.0...v2.1.0
 [2.1.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v2.1.0...v2.1.1
 [2.1.2]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v2.1.1...v2.1.2
 [2.2.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v2.1.2...v2.2.0
+[2.2.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v2.2.0...v2.2.1
 [3.0.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v2.0.0...v3.0.0
 [3.0.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.0.0...v3.0.1
 [3.0.2]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.0.1...v3.0.2
 [3.1.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.0.2...v3.1.0
 [3.1.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.1.0...v3.1.1
 [3.2.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.1.1...v3.2.0
-[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.2.0...main
+[3.3.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.2.0...v3.3.0
+[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.3.0...main

--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -77,9 +77,9 @@ type service struct {
 	client *resty.Client
 }
 
-// SetAuthToken defines the Authorization token sent in the request
+// SetAuthToken defines the X-Auth-Token token sent in the request
 func (s *Client) SetAuthToken(accessToken string) {
-	s.SetAuthToken(accessToken)
+	s.common.client.SetHeader("X-Auth-Token", accessToken)
 }
 
 // Error indicates an error from the invocation of a Cisco DNA Center API.
@@ -249,7 +249,7 @@ func (s *Client) AuthClient() error {
 		error := response.Error()
 		return fmt.Errorf("%s", error)
 	}
-	s.common.client.SetHeader("X-Auth-Token", result.Token)
+	s.SetAuthToken(result.Token)
 
 	return nil
 }

--- a/sdk/application_policy.go
+++ b/sdk/application_policy.go
@@ -419,11 +419,20 @@ type ResponseApplicationPolicyDeleteApplicationResponse struct {
 }
 type ResponseApplicationPolicyGetApplications []ResponseItemApplicationPolicyGetApplications // Array of ResponseApplicationPolicyGetApplications
 type ResponseItemApplicationPolicyGetApplications struct {
-	ID                  string                                                             `json:"id,omitempty"`                  // Id
-	Name                string                                                             `json:"name,omitempty"`                // Name
-	NetworkApplications *[]ResponseItemApplicationPolicyGetApplicationsNetworkApplications `json:"networkApplications,omitempty"` //
-	NetworkIDentity     *[]ResponseItemApplicationPolicyGetApplicationsNetworkIDentity     `json:"networkIdentity,omitempty"`     //
-	ApplicationSet      *ResponseItemApplicationPolicyGetApplicationsApplicationSet        `json:"applicationSet,omitempty"`      //
+	ID                        string                                                                   `json:"id,omitempty"`                        // Id
+	Name                      string                                                                   `json:"name,omitempty"`                      // Name
+	IndicativeNetworkIDentity *[]ResponseItemApplicationPolicyGetApplicationsIndicativeNetworkIDentity `json:"indicativeNetworkIdentity,omitempty"` //
+	NetworkApplications       *[]ResponseItemApplicationPolicyGetApplicationsNetworkApplications       `json:"networkApplications,omitempty"`       //
+	NetworkIDentity           *[]ResponseItemApplicationPolicyGetApplicationsNetworkIDentity           `json:"networkIdentity,omitempty"`           //
+	ApplicationSet            *ResponseItemApplicationPolicyGetApplicationsApplicationSet              `json:"applicationSet,omitempty"`            //
+}
+type ResponseItemApplicationPolicyGetApplicationsIndicativeNetworkIDentity struct {
+	ID          string `json:"id,omitempty"`          // id
+	DisplayName string `json:"displayName,omitempty"` // displayName
+	LowerPort   *int   `json:"lowerPort,omitempty"`   // lowerPort
+	Ports       string `json:"ports,omitempty"`       // ports
+	Protocol    string `json:"protocol,omitempty"`    // protocol
+	UpperPort   *int   `json:"upperPort,omitempty"`   // upperPort
 }
 type ResponseItemApplicationPolicyGetApplicationsNetworkApplications struct {
 	ID                 string `json:"id,omitempty"`                 // Id

--- a/sdk/sites.go
+++ b/sdk/sites.go
@@ -185,7 +185,7 @@ type ResponseSitesGetSiteHealthResponseApplicationHealthStatsDefaultHealthAppCou
 	Good *float64 `json:"good,omitempty"` // Good
 }
 type ResponseSitesGetSiteCount struct {
-	Response string `json:"response,omitempty"` // Response
+	Response *int   `json:"response,omitempty"` // Response
 	Version  string `json:"version,omitempty"`  // Version
 }
 type ResponseSitesUpdateSite struct {


### PR DESCRIPTION
### Added
- application_policy - Adds IndicativeNetworkIdentity property to ResponseItemApplicationPolicyGetApplications struct
- application_policy - Adds ResponseItemApplicationPolicyGetApplicationsIndicativeNetworkIDentity struct

### Fixed
- Fix SetAuthToken to use DNAC X-Auth-Token
- sites - Response of ResponseSitesGetSiteCount type changes from string to *int