### PR TITLE
- Removed from `RequestDeviceOnboardingPnpClaimADeviceToASite` follow…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [3.6.1] - 2022-03-16
+### Removed
+- Removed from `RequestDeviceOnboardingPnpClaimADeviceToASite` following pointers.
+    + `RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo`.
+    + `RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo`.
+- Removed from `RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo` following pointers.
+    + `Skip`.
+- Removed from `RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo` following pointers.
+    + `RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfoConfigParameters`.
+- Removed `omitempty` for following variables.
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ImageInfo`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ImageInfo.ImageID`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ImageInfo.Skip`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigID`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigParameters`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigParameters.Key`
+    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigParameters.Value`
+  
 ## [3.6.0] - 2022-03-15
 ### Added
 - Added new service `CustomCallService`
@@ -292,4 +311,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [3.5.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.4.1...v3.5.0
 [3.5.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.5.0...v3.5.1
 [3.6.0]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.5.1...v3.6.0
-[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.6.0...main
+[3.6.1]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.6.0...v3.6.1
+[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v3.6.1...main

--- a/sdk/device_onboarding_pnp.go
+++ b/sdk/device_onboarding_pnp.go
@@ -3284,24 +3284,24 @@ type RequestDeviceOnboardingPnpResetDeviceDeviceResetListConfigListConfigParamet
 	Value string `json:"value,omitempty"` //
 }
 type RequestDeviceOnboardingPnpClaimADeviceToASite struct {
-	DeviceID   string                                                   `json:"deviceId,omitempty"`   //
-	SiteID     string                                                   `json:"siteId,omitempty"`     //
-	Type       string                                                   `json:"type,omitempty"`       //
-	ImageInfo  *RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo  `json:"imageInfo,omitempty"`  //
-	ConfigInfo *RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo `json:"configInfo,omitempty"` //
-	Hostname   string                                                   `json:"hostname,omitempty"`   //
+	DeviceID   string                                                  `json:"deviceId,omitempty"` //
+	SiteID     string                                                  `json:"siteId,omitempty"`   //
+	Type       string                                                  `json:"type,omitempty"`     //
+	ImageInfo  RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo  `json:"imageInfo"`          //
+	ConfigInfo RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo `json:"configInfo"`         //
+	Hostname   string                                                  `json:"hostname,omitempty"` //
 }
 type RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo struct {
-	ImageID string `json:"imageId,omitempty"` //
-	Skip    *bool  `json:"skip,omitempty"`    //
+	ImageID string `json:"imageId"`
+	Skip    bool   `json:"skip"                ` //
 }
 type RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo struct {
-	ConfigID         string                                                                     `json:"configId,omitempty"`         //
-	ConfigParameters *[]RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfoConfigParameters `json:"configParameters,omitempty"` //
+	ConfigID         string                                                                    `json:"configId"`         //
+	ConfigParameters []RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfoConfigParameters `json:"configParameters"` //
 }
 type RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfoConfigParameters struct {
-	Key   string `json:"key,omitempty"`   //
-	Value string `json:"value,omitempty"` //
+	Key   string `json:"key"`   //
+	Value string `json:"value"` //
 }
 type RequestDeviceOnboardingPnpPreviewConfig struct {
 	DeviceID string `json:"deviceId,omitempty"` //


### PR DESCRIPTION
…ing pointers.

    + `RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo`.
    + `RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo`.
- Removed from `RequestDeviceOnboardingPnpClaimADeviceToASiteImageInfo` following pointers.
    + `Skip`.
- Removed from `RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfo` following pointers.
    + `RequestDeviceOnboardingPnpClaimADeviceToASiteConfigInfoConfigParameters`.
- Removed `omitempty` for following variables.
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ImageInfo`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ImageInfo.ImageID`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ImageInfo.Skip`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigID`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigParameters`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigParameters.Key`
    + `RequestDeviceOnboardingPnpClaimADeviceToASite.ConfigInfo.ConfigParameters.Value`