### PR TITLE
v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [4.0.2] - 2022-07-08
+### Changed
+- `event_management.ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetails.TrustCert` parameter turns to `boolean`.
+- `event_management.ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetails.ConnectTimeout` parameter turns to `number`.
+- `event_management.ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetails.ReadTimeout` parameter turns to `number`.
+  
+### Added
+- Added `SiteNameHierarchy`, `FabricName`, `FabricType` and `FabricDomainType` to
+`ResponseSdaGetSiteFromSdaFabric` of `sda`
 ## [4.0.1] - 2022-06-17
 ### Changed
 - `discovery.ResponseDiscoveryGetGlobalCredentialsResponse.Secure` parameter turns to `boolean`.

--- a/sdk/event_management.go
+++ b/sdk/event_management.go
@@ -347,13 +347,13 @@ type ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscr
 	BasePath       string                                                                                                 `json:"basePath,omitempty"`       // Base Path
 	Resource       string                                                                                                 `json:"resource,omitempty"`       // Resource
 	Method         string                                                                                                 `json:"method,omitempty"`         // Method
-	TrustCert      string                                                                                                 `json:"trustCert,omitempty"`      // Trust Cert
+	TrustCert      *bool                                                                                                  `json:"trustCert,omitempty"`      // Trust Cert **
 	Headers        *[]ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetailsHeaders     `json:"headers,omitempty"`        //
 	QueryParams    *[]ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetailsQueryParams `json:"queryParams,omitempty"`    //
 	PathParams     *[]ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetailsPathParams  `json:"pathParams,omitempty"`     //
 	Body           string                                                                                                 `json:"body,omitempty"`           // Body
-	ConnectTimeout string                                                                                                 `json:"connectTimeout,omitempty"` // Connect Timeout
-	ReadTimeout    string                                                                                                 `json:"readTimeout,omitempty"`    // Read Timeout
+	ConnectTimeout *int                                                                                                   `json:"connectTimeout,omitempty"` // Connect Timeout **
+	ReadTimeout    *int                                                                                                   `json:"readTimeout,omitempty"`    // Read Timeout **
 }
 type ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetailsHeaders struct {
 	String string `json:"string,omitempty"` // String

--- a/sdk/sda.go
+++ b/sdk/sda.go
@@ -370,9 +370,13 @@ type ResponseSdaGetEdgeDeviceFromSdaFabric struct {
 	SiteHierarchy             string   `json:"siteHierarchy,omitempty"`             // Site Hierarchy
 }
 type ResponseSdaGetSiteFromSdaFabric struct {
-	Status             string `json:"status,omitempty"`             // Status
-	Description        string `json:"description,omitempty"`        // Description
-	ExecutionStatusURL string `json:"executionStatusUrl,omitempty"` // Execution Status Url
+	SiteNameHierarchy  *string `json:"siteNameHierarchy,omitempty"`  // SiteNameHierarchy **
+	FabricName         *string `json:"fabricName,omitempty"`         // FabricName **
+	FabricType         *string `json:"fabricType,omitempty"`         // FabricType **
+	FabricDomainType   *string `json:"fabricDomainType,omitempty"`   // FabricDomainType **
+	Status             string  `json:"status,omitempty"`             // Status
+	Description        string  `json:"description,omitempty"`        // Description
+	ExecutionStatusURL string  `json:"executionStatusUrl,omitempty"` // Execution Status Url
 }
 type ResponseSdaDeleteSiteFromSdaFabric struct {
 	Status             string `json:"status,omitempty"`             // represents return status of API. status=success when API completed successfully, status=failed when API failed and has not completed the user request, status=pending when API execution is still in progression and user needs to track its further progress via taskId field.


### PR DESCRIPTION
- `event_management.ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetails.TrustCert` parameter turns to `boolean`.
- `event_management.ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetails.ConnectTimeout` parameter turns to `number`.
- `event_management.ResponseItemEventManagementGetEventSubscriptionsSubscriptionEndpointsSubscriptionDetails.ReadTimeout` parameter turns to `number`.

### Added
- Added `SiteNameHierarchy`, `FabricName`, `FabricType` and `FabricDomainType` to
`ResponseSdaGetSiteFromSdaFabric` of `sda`