### PR TITLE
Bug Fix: Changed the type of ResponseClientsGetClientDetailDetail.detail.vlan from string to int

### DIFF
--- a/sdk/clients.go
+++ b/sdk/clients.go
@@ -48,7 +48,7 @@ type ResponseClientsGetClientDetailDetail struct {
 	HostIPV6         []string                                               `json:"hostIpV6,omitempty"`         // Host Ip V6
 	AuthType         string                                                 `json:"authType,omitempty"`         // Auth Type
 	VLANID           string                                                 `json:"vlanId,omitempty"`           // Vlan Id
-	Vnid             string                                                 `json:"vnid,omitempty"`             // Vnid
+	Vnid             *int                                                   `json:"vnid,omitempty"`             // Vnid
 	SSID             string                                                 `json:"ssid,omitempty"`             // Ssid
 	Frequency        string                                                 `json:"frequency,omitempty"`        // Frequency
 	Channel          string                                                 `json:"channel,omitempty"`          // Channel


### PR DESCRIPTION
**Bug Fix**

**Prerequisites**
* [ x ] Have you tested the operation in the API directly?
* [ x ] Do you have the latest SDK version?


**Describe the bug**

When running `GetClientDetail` on two different DNAC instances we get the following error
```bash
2022/10/26 14:25:23.234748 ERROR RESTY json: cannot unmarshal number into Go struct field ResponseClientsGetClientDetailDetail.detail.vlanId of type string, Attempt 1
json: cannot unmarshal number into Go struct field ResponseClientsGetClientDetailDetail.detail.vlanId of type string
```
**Expected behavior**

We were expected to receive `ResponseClientsGetClientDetailDetail`, but instead we received the above error.

**Environment (please complete the following information):**
* Cisco DNA Center Version and patch: 2.3.4.0-70523 and 2.3.3.5-70134
* Go Version: 1.15
* SDK version: v4.0.8
* OS Version: macOS Monterey 12.6

**Additional context**

Code:
```go
package main

import (
	"fmt"
	dnacSdk "github.com/cisco-en-programmability/dnacenter-go-sdk/v4/sdk"
)

func main() {
	client, err := dnacSdk.NewClient()

	if err != nil {
		fmt.Println(err)
	}
	getClientDetailQueryParams := &dnacSdk.GetClientDetailQueryParams{
		MacAddress: "REDACTED", // Redacted for security reasons

	}
	_, response, err := client.Clients.GetClientDetail(getClientDetailQueryParams)

	if err != nil{
		fmt.Println(err)
		return
	}
	fmt.Println(response)

}
```
go.mod:
```text
module scratches

go 1.15

require (
	github.com/cisco-en-programmability/dnacenter-go-sdk/v4 v4.0.8
	golang.org/x/net v0.1.0 // indirect
)
```

Full Output:
```bash
GOROOT=REDACTED/Cellar/go/1.18.2/libexec #gosetup
GOPATH=/Users/REDACTED/go #gosetup
2022/10/26 14:29:35.742396 DEBUG RESTY 
==============================================================================
~~~ REQUEST ~~~
POST  /dna/system/api/v1/auth/token  HTTP/1.1
HOST   : REDACTED
HEADERS:
        Authorization: Basic <REDACTED>
        User-Agent: go-resty/2.7.0 (https://github.com/go-resty/resty)
BODY   :
***** NO CONTENT *****
------------------------------------------------------------------------------
~~~ RESPONSE ~~~
STATUS       : 200 OK
PROTO        : HTTP/1.1
RECEIVED AT  : 2022-10-26T14:29:35.721278-06:00
TIME DURATION: 869.508566ms
HEADERS      :
        Access-Control-Allow-Origin: REDACTED
        Cache-Control: no-store
        Connection: keep-alive
        Content-Length: 743
        Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:
        Content-Type: application/json
        Date: Wed, 26 Oct 2022 20:29:34 GMT
        Pragma: no-cache
        Server: webserver
        Strict-Transport-Security: max-age=31536000; includeSubDomains
        Vary: Origin
        Via: api-gateway
        X-Content-Type-Options: nosniff
        X-Frame-Options: SAMEORIGIN
        X-Password-Expiry-Days: -1, -1, -1
        X-Request-Id: 7e51726b3db9563f2e25a7e9f8400a86
        X-Xss-Protection: 1
BODY         :
{
   "Token": "<REDACTED>"
}
==============================================================================
2022/10/26 14:29:37.571969 DEBUG RESTY 
==============================================================================
~~~ REQUEST ~~~
GET  /dna/intent/api/v1/client-detail?macAddress=REDACTED HTTP/1.1
HOST   : REDACTED
HEADERS:
        Accept: application/json
        Content-Type: application/json
        User-Agent: go-resty/2.7.0 (https://github.com/go-resty/resty)
        X-Auth-Token: <REDACTED>
BODY   :
***** NO CONTENT *****
------------------------------------------------------------------------------
~~~ RESPONSE ~~~
STATUS       : 200 OK
PROTO        : HTTP/1.1
RECEIVED AT  : 2022-10-26T14:29:37.571572-06:00
TIME DURATION: 1.82821326s
HEADERS      :
        Access-Control-Allow-Origin: REDACTED
        Bapiexecutionid: e3b9affa-43c4-481b-984b-22fd61381f8e
        Cache-Control: no-store
        Connection: keep-alive
        Content-Length: 5053
        Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:
        Content-Type: application/json
        Date: Wed, 26 Oct 2022 20:29:36 GMT
        Pragma: no-cache
        Server: webserver
        Strict-Transport-Security: max-age=31536000; includeSubDomains
        Vary: Origin
        Via: api-gateway
        X-Content-Type-Options: nosniff
        X-Frame-Options: SAMEORIGIN
        X-Request-Id: 88d40c85762dc079f82bb188ba5c7efe
        X-Xss-Protection: 1
BODY         :
{
   "detail": {
      "id": "REDACTED",
      "connectionStatus": "CONNECTING",
      "tracked": "No",
      "hostType": "WIRELESS",
      "userId": "REDACTED",
      "duid": "",
      "hostName": "REDACTED",
      "hostOs": "VMware ESX Server 3.0.0 - 3.5.0 (accuracy 90%)",
      "hostVersion": null,
      "subType": "Mac-OS_X-Casper-Managed",
      "firmwareVersion": null,
      "deviceVendor": null,
      "deviceForm": null,
      "salesCode": null,
      "countryCode": null,
      "lastUpdated": 1666812198365,
      "healthScore": [
         {
            "healthType": "OVERALL",
            "reason": "",
            "score": 1
         },
         {
            "healthType": "ONBOARDED",
            "reason": "",
            "score": 1
         },
         {
            "healthType": "CONNECTED",
            "reason": "",
            "score": 0
         }
      ],
      "hostMac": "REDACTED",
      "hostIpV4": "REDACTED",
      "hostIpV6": [
         "REDACTED",
         "REDACTED"
      ],
      "authType": "REDACTED",
      "vlanId": 1,
      "l3VirtualNetwork": "User",
      "l2VirtualNetwork": "Data",
      "vnid": 8192,
      "upnId": "0",
      "upnName": null,
      "ssid": "REDACTED",
      "frequency": "5",
      "channel": "56",
      "apGroup": "UNKNOWN",
      "sgt": "0.0",
      "location": "REDACTED",
      "clientConnection": "REDACTED",
      "connectedDevice": [
         {
            "type": null,
            "name": "REDACTED",
            "mac": "REDACTED",
            "id": "REDACTED",
            "ip address": null,
            "mgmtIp": null,
            "band": null,
            "mode": "Unknown"
         }
      ],
      "issueCount": 0,
      "rssi": "0.0",
      "rssiThreshold": "-72.0",
      "rssiIsInclude": "true",
      "avgRssi": "0.0",
      "snr": "0.0",
      "snrThreshold": "9.0",
      "snrIsInclude": "true",
      "avgSnr": "0.0",
      "dataRate": "289.0",
      "txBytes": "0.0",
      "rxBytes": "0.0",
      "dnsResponse": "0.0",
      "dnsRequest": "0.0",
      "onboarding": {
         "averageRunDuration": "122.0",
         "maxRunDuration": "122.0",
         "averageAssocDuration": "1.0",
         "maxAssocDuration": "1.0",
         "averageAuthDuration": "96.0",
         "maxAuthDuration": "96.0",
         "averageDhcpDuration": null,
         "maxDhcpDuration": null,
         "aaaServerIp": "REDACTED",
         "dhcpServerIp": "UNKNOWN",
         "authDoneTime": 1665701576914,
         "assocDoneTime": 1665701576818,
         "dhcpDoneTime": 1665687125917,
         "aaaRootcauseList": [
            "cl_CO_CLIENT_CONNECT_TIMEOUT"
         ],
         "latestRootCauseList": [
            "aaaRootCause"
         ]
      },
      "clientType": "OLD",
      "onboardingTime": 1665701576939,
      "port": null,
      "iosCapable": false,
      "usage": 0,
      "linkSpeed": 0,
      "linkThreshold": "I_1.0",
      "remoteEndDuplexMode": null,
      "txLinkError": 0,
      "rxLinkError": 0,
      "txRate": 0,
      "rxRate": 0,
      "rxRetryPct": "0.0",
      "versionTime": null,
      "dot11Protocol": "802.11ac",
      "slotId": 1,
      "dot11ProtocolCapability": "802.11ac",
      "privateMac": false,
      "dhcpServerIp": null,
      "aaaServerIp": null,
      "aaaServerTransaction": null,
      "aaaServerFailedTransaction": null,
      "aaaServerSuccessTransaction": null,
      "aaaServerLatency": null,
      "aaaServerMABLatency": null,
      "aaaServerEAPLatency": null,
      "dhcpServerTransaction": null,
      "dhcpServerFailedTransaction": null,
      "dhcpServerSuccessTransaction": null,
      "dhcpServerLatency": null,
      "dhcpServerDOLatency": null,
      "dhcpServerRALatency": null,
      "maxRoamingDuration": "2601.0",
      "upnOwner": null,
      "connectedUpn": null,
      "connectedUpnOwner": null,
      "connectedUpnId": null,
      "isGuestUPNEndpoint": null,
      "wlcName": "REDACTED",
      "wlcUuid": "REDACTED",
      "sessionDuration": null,
      "intelCapable": false,
      "hwModel": null,
      "powerType": null,
      "modelName": null
   },
   "connectionInfo": {
      "hostType": "WIRELESS",
      "nwDeviceName": "REDACTED",
      "nwDeviceMac": "REDACTED",
      "protocol": "802.11ac",
      "band": "5",
      "spatialStream": "3",
      "channel": "56",
      "channelWidth": "20",
      "wmm": "Supported",
      "uapsd": "Disabled",
      "timestamp": 1666815960000
   },
   "topology": {
      "nodes": [
         {
            "role": "CLIENT",
            "name": null,
            "id": "REDACTED",
            "description": "Client",
            "deviceType": null,
            "platformId": null,
            "family": null,
            "ip": "REDACTED",
            "ipv6": [
               "REDACTED",
               "REDACTED"
            ],
            "softwareVersion": null,
            "userId": null,
            "nodeType": "Interface",
            "radioFrequency": null,
            "clients": null,
            "count": null,
            "healthScore": null,
            "level": 0,
            "fabricGroup": null,
            "connectedDevice": null,
            "stackType": null,
            "additionalInfo": {
               "macAddress": "REDACTED"
            }
         }
      ]
   }
}
==============================================================================
2022/10/26 14:29:37.575397 ERROR RESTY json: cannot unmarshal number into Go struct field ResponseClientsGetClientDetailDetail.detail.vlanId of type string, Attempt 1
json: cannot unmarshal number into Go struct field ResponseClientsGetClientDetailDetail.detail.vlanId of type string

```


Co-authored-by: Pablo Gabriel Echegorri (legion49f)  <pabloechegorri@gmail.com>