### PR TITLE
chore:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.0.28] - 2024-06-04
 - `TopOfStackSerialNumber` and `CablingScheme` added to `RequestDeviceOnboardingPnpClaimADeviceToASite`
+- Fix `ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetails` to support empty string
 
 ## [5.0.27] - 2024-04-22
 - Function `GetTemplatesDetails` change response struct from an object to an array objects.
 
 ## [5.0.26] - 2024-04-22
-- Functions were modified to be called recursively in case of Status Unauthorized.
- 
+- Functions were modified to be called recursively in case of Status Unauthorized. 
 
 ## [5.0.25] - 2024-02-13
 - `EndTime` attribute change to `*int` in `ResponseTaskGetTaskTreeResponse`.
@@ -625,4 +627,5 @@ Services removed on Cisco DNA Center 2.3.3.0's API:
 [5.0.25]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v5.0.24...v5.0.25
 [5.0.26]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v5.0.25...v5.0.26
 [5.0.27]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v5.0.26...v5.0.27
-[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v5.0.27...main
+[5.0.27]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v5.0.27...v5.0.28
+[Unreleased]: https://github.com/cisco-en-programmability/dnacenter-go-sdk/compare/v5.0.28...main

--- a/sdk/wireless.go
+++ b/sdk/wireless.go
@@ -1,6 +1,7 @@
 package dnac
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -427,6 +428,40 @@ type ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetails struct {
 	FlexConnect   *ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetailsFlexConnect `json:"flexConnect,omitempty"`   //
 	InterfaceName string                                                                      `json:"interfaceName,omitempty"` // Interface Name
 }
+
+func (r *ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetails) UnmarshalJSON(data []byte) error {
+	type Alias ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetails
+	aux := &struct {
+		EnableFabric interface{} `json:"enableFabric"`
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	switch v := aux.EnableFabric.(type) {
+	case bool:
+		r.EnableFabric = &v
+	case string:
+		if v == "true" {
+			r.EnableFabric = new(bool)
+			*r.EnableFabric = true
+		} else if v == "false" {
+			r.EnableFabric = new(bool)
+			*r.EnableFabric = false
+		} else {
+			r.EnableFabric = nil
+		}
+	case nil:
+		r.EnableFabric = nil
+	default:
+		r.EnableFabric = nil
+	}
+
+	return nil
+}
+
 type ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetailsFlexConnect struct {
 	EnableFlexConnect *bool `json:"enableFlexConnect,omitempty"` // true if flex connect is enabled else false
 	LocalToVLAN       *int  `json:"localToVlan,omitempty"`       // Local To VLAN ID


### PR DESCRIPTION
- `TopOfStackSerialNumber` and `CablingScheme` added to `RequestDeviceOnboardingPnpClaimADeviceToASite`
- Fix `ResponseItemWirelessGetWirelessProfileProfileDetailsSSIDDetails` to support empty string